### PR TITLE
Drop < prefix from channel returning fns.

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -3,10 +3,10 @@
             [clojure.tools.namespace.repl :as repl]))
 
 (defn test-db []
-  (pg/open-db {:hostname "localhost"
-               :database "postgres"
-               :username "postgres"
-               :password "postgres"}))
+  (pg/open {:hostname "localhost"
+            :database "postgres"
+            :username "postgres"
+            :password "postgres"}))
 
 (defn reload []
   (repl/refresh))

--- a/src/postgres/async.clj
+++ b/src/postgres/async.clj
@@ -1,8 +1,8 @@
 (ns postgres.async
-  (:require [postgres.async.impl :refer [consumer-fn defasync] :as pg]
-            [clojure.core.async :refer [<!]])
-  (:import [com.github.pgasync Db ConnectionPoolBuilder
-            QueryExecutor TransactionExecutor Transaction]
+  (:require [postgres.async.impl :as pg]
+            [clojure.core.async :refer [<!] :as async]
+            postgres.async.cb)
+  (:import [com.github.pgasync Db ConnectionPoolBuilder]
            [com.github.pgasync.impl.conversion DataConverter]))
 
 (defmulti from-pg-value (fn [oid value] oid))
@@ -16,7 +16,7 @@
     (fromConvertable [value]
       (to-pg-value value))))
 
-(defn open-db
+(defn open
   "Creates a db connection pool"
   [{:keys [hostname port username password database pool-size] :as config}]
   (doseq [param [:hostname :username :password :database]]
@@ -32,82 +32,26 @@
       (.dataConverter (create-converter))
       (.build)))
 
-(defn close-db!
+(defn close!
   "Closes a db connection pool"
   [^Db db]
   (.close db))
 
-(defn execute!
-  "Executes an sql statement and calls (f result-set exception) on completion"
-  [^QueryExecutor db [sql & params] f]
-  (.query db sql params
-          (consumer-fn [rs]
-                       (f (pg/result->map rs) nil))
-          (consumer-fn [exception]
-                       (f nil exception))))
+(defmacro defasync [name args]
+  `(defn ~name [~@args]
+     (let [ch# (async/chan 1)]
+       (~(symbol (str "postgres.async.cb/" name)) ~@args (fn [rs# err#]
+                                                           (async/put! ch# (or rs# err#))
+                                                           (async/close! ch#)))
+       ch#)))
 
-(defn query!
-  "Executes an sql query and calls (f rows exception) on completion"
-  [db sql f]
-  (execute! db sql (fn [rs err]
-                     (f (:rows rs) err))))
-
-(defn insert!
-  "Executes an sql insert and calls (f result-set exception) on completion.
-   Spec format is
-     :table - table name
-     :returning - sql string"
-  [db sql-spec data f]
-  (execute! db (list* (pg/create-insert-sql sql-spec data)
-                      (if (map? data)
-                        (vals data)
-                        (flatten (map vals data))))
-          f))
-
-(defn update!
-  "Executes an sql update and calls (f result-set exception) on completion.
-   Spec format is
-     :table - table name
-     :returning - sql string
-     :where - [sql & params]"
-  [db sql-spec data f]
-  (execute! db (flatten [(pg/create-update-sql sql-spec data)
-                        (rest (:where sql-spec))
-                        (vals data)])
-          f))
-
-(defn begin!
-  "Begins a transaction and calls (f transaction exception) on completion"
-  [^TransactionExecutor db f]
-  (.begin db
-          (consumer-fn [tx]
-                       (f tx nil))
-          (consumer-fn [exception]
-                       (f nil exception))))
-
-(defn commit!
-  "Commits an active transaction and calls (f true exception) on completion"
-  [^Transaction tx f]
-  (.commit tx
-           #(f true nil)
-           (consumer-fn [exception]
-                        (f nil exception))))
-
-(defn rollback!
-  "Rollbacks an active transaction and calls (f true exception) on completion"
-  [^Transaction tx f]
-  (.rollback tx
-             #(f true nil)
-             (consumer-fn [exception]
-                          (f nil exception))))
-
-(defasync <execute!  [db query])
-(defasync <query!    [db query])
-(defasync <insert!   [db sql-spec data])
-(defasync <update!   [db sql-spec data])
-(defasync <begin!    [db])
-(defasync <commit!   [tx])
-(defasync <rollback! [tx])
+(defasync execute!  [db query])
+(defasync query!    [db query])
+(defasync insert!   [db sql-spec data])
+(defasync update!   [db sql-spec data])
+(defasync begin!    [db])
+(defasync commit!   [tx])
+(defasync rollback! [tx])
 
 (defmacro dosql
   "Takes values from channels returned by db functions and returns exception

--- a/src/postgres/async/cb.clj
+++ b/src/postgres/async/cb.clj
@@ -1,0 +1,67 @@
+(ns postgres.async.cb
+  (:require [postgres.async.impl :refer [consumer-fn] :as pg])
+  (:import [com.github.pgasync QueryExecutor TransactionExecutor Transaction]))
+
+(defn execute!
+  "Executes an sql statement and calls (f result-set exception) on completion"
+  [^QueryExecutor db [sql & params] f]
+  (.query db sql params
+          (consumer-fn [rs]
+                       (f (pg/result->map rs) nil))
+          (consumer-fn [exception]
+                       (f nil exception))))
+
+(defn query!
+  "Executes an sql query and calls (f rows exception) on completion"
+  [db sql f]
+  (execute! db sql (fn [rs err]
+                     (f (:rows rs) err))))
+
+(defn insert!
+  "Executes an sql insert and calls (f result-set exception) on completion.
+   Spec format is
+     :table - table name
+     :returning - sql string"
+  [db sql-spec data f]
+  (execute! db (list* (pg/create-insert-sql sql-spec data)
+                      (if (map? data)
+                        (vals data)
+                        (flatten (map vals data))))
+            f))
+
+(defn update!
+  "Executes an sql update and calls (f result-set exception) on completion.
+   Spec format is
+     :table - table name
+  :returning - sql string
+  :where - [sql & params]"
+  [db sql-spec data f]
+  (execute! db (flatten [(pg/create-update-sql sql-spec data)
+                         (rest (:where sql-spec))
+                         (vals data)])
+            f))
+
+(defn begin!
+  "Begins a transaction and calls (f transaction exception) on completion"
+  [^TransactionExecutor db f]
+  (.begin db
+          (consumer-fn [tx]
+                       (f tx nil))
+          (consumer-fn [exception]
+                       (f nil exception))))
+
+(defn commit!
+  "Commits an active transaction and calls (f true exception) on completion"
+  [^Transaction tx f]
+  (.commit tx
+           #(f true nil)
+           (consumer-fn [exception]
+                        (f nil exception))))
+
+(defn rollback!
+  "Rollbacks an active transaction and calls (f true exception) on completion"
+  [^Transaction tx f]
+  (.rollback tx
+             #(f true nil)
+             (consumer-fn [exception]
+                          (f nil exception))))

--- a/src/postgres/async/impl.clj
+++ b/src/postgres/async/impl.clj
@@ -1,17 +1,8 @@
 (ns postgres.async.impl
-  (:require [clojure.string :as string]
-            [clojure.core.async :refer [chan close! put! go]])
+  (:require [clojure.string :as string])
   (:import [java.util.function Consumer]
            [com.github.pgasync ResultSet]
            [com.github.pgasync.impl PgRow]))
-
-(defmacro defasync [name args]
-  `(defn ~name [~@args]
-     (let [c# (chan 1)]
-       (~(symbol (subs (str name) 1)) ~@args #(do
-                                                (put! c# (or %2 %1))
-                                                (close! c#)))
-       c#)))
 
 (defmacro consumer-fn [[param] body]
   `(reify Consumer (accept [_# ~param]


### PR DESCRIPTION
I’m assuming just about anyone using this library is interesting in using it with core.async.  Therefore, I moved the callback versions of execute!, query!, etc. to a separate namespace, thereby allowing for the channel returning versions to have the same names.  Also removed the -db suffix from open and close since there is no reason to disambiguate those functions.

Also, I think the language should be changed from open returning a db, to a connection, as that more accurately reflects what’s going on.  That’s only a small naming change, but it helps to keep things clear.

Example usage:

```clojure
(require '[postgres.async :as db])

(def conn (db/open {:hostname ...}))

(<!! (db/query! conn ["SELECT * FROM my-table LIMIT 10"]))
```